### PR TITLE
Add ceph python libs

### DIFF
--- a/dockerfiles/Dockerfile-centos
+++ b/dockerfiles/Dockerfile-centos
@@ -48,7 +48,6 @@ RUN set -x \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt python-memcached pymysql \
 # Project specific command block end
     && yum history -y undo $(yum history list git | tail -2 | head -1 | awk '{ print $1}') \
-    && rpm -e --nodeps centos-logos \
     && yum clean all \
     && rm -rf /tmp/* /root/.cache \
     && find / -type f \( -name "*.pyc" -o -name "pip" -o -name "easy_install" -o -name "wheel" \) -delete

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -10,10 +10,13 @@ ARG GIT_REF
 ARG GIT_REF_REPO=https://git.openstack.org/openstack/${PROJECT}
 
 RUN set -x \
+    && apt-key adv --fetch-keys "http://download.ceph.com/keys/release.asc" \
+    && echo "deb http://download.ceph.com/debian-jewel jessie main" > /etc/apt/sources.list.d/ceph.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
 # Project specific packages start
         python \
+        python-rados \
 # Project specific packages end
     && apt-get install -y --no-install-recommends ca-certificates curl git \
 # common install start
@@ -37,7 +40,7 @@ RUN set -x \
     && python get-pip.py \
     && rm get-pip.py \
     && pip install virtualenv \
-    && virtualenv /virtualenv \
+    && virtualenv --system-site-packages /virtualenv \
     && hash -r \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt /tmp/${PROJECT} \
     && groupadd -g 42424 ${PROJECT} \

--- a/dockerfiles/Dockerfile-ubuntu
+++ b/dockerfiles/Dockerfile-ubuntu
@@ -10,10 +10,13 @@ ARG GIT_REF
 ARG GIT_REF_REPO=https://git.openstack.org/openstack/${PROJECT}
 
 RUN set -x \
+    && apt-key adv --fetch-keys "http://download.ceph.com/keys/release.asc" \
+    && echo "deb http://download.ceph.com/debian-jewel xenial main" > /etc/apt/sources.list.d/ceph.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
 # Project specific packages start
         python \
+        python-rados \
 # Project specific packages end
     && apt-get install -y --no-install-recommends ca-certificates curl git \
 # common install start
@@ -37,7 +40,7 @@ RUN set -x \
     && python get-pip.py \
     && rm get-pip.py \
     && pip install virtualenv \
-    && virtualenv /virtualenv \
+    && virtualenv --system-site-packages /virtualenv \
     && hash -r \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt /tmp/${PROJECT} \
     && groupadd -g 42424 ${PROJECT} \


### PR DESCRIPTION
We have to update the virtualenv to allow it access to the system
python packages to access python-ceph. According to the ceph-devs, in
the next release of Ceph (Kraken) the python libs will be published to
PyPI. That is expected any day now.